### PR TITLE
the March middleware trued - relative import, honest matcher

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,11 @@
-// app/middleware.ts
+// app/middleware.ts — the session-refresh gate.
+// Trued 2026-08-14 at KP's word (the March file guarded rooms that no
+// longer exist: /creator, /vendor, /admin, /profile/edit). The import is
+// RELATIVE on purpose: Vercel's Edge bundling failed to resolve the "@/"
+// alias while the project's framework preset was unset, and a relative
+// path survives every builder.
 import { type NextRequest } from 'next/server';
-import { updateSession } from '@/lib/supabase/middleware';
+import { updateSession } from './src/lib/supabase/middleware';
 
 export async function middleware(request: NextRequest) {
   return await updateSession(request);
@@ -9,17 +14,11 @@ export async function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     /*
-     * Match all request paths except for the ones starting with:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     * Feel free to modify this pattern to include more paths.
+     * Refresh the session on every request except static assets:
+     * - _next/static, _next/image, favicon.ico, and image files.
+     * Realm-level protection lives with the realms; this gate only
+     * keeps the session honest.
      */
-    '/dashboard/:path*',
-    '/profile/edit/:path*',
-    '/creator/:path*',
-    '/vendor/:path*',
-    '/admin/:path*',
     '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 };


### PR DESCRIPTION
The root middleware.ts dated to the first commits: its matcher guarded /creator /vendor /admin /profile/edit - rooms that no longer exist - and its @/ alias import is what Vercel's preset-less builder could not resolve (framework: null since the legacy vercel.json left, 04-13). The import is now relative so no builder can fumble it; the matcher keeps only the honest catch-all. Session refresh unchanged - the SSR body was always healthy.